### PR TITLE
Renewal Path64, PathD, Paths64, PathsD.

### DIFF
--- a/src/Core/Path64.ts
+++ b/src/Core/Path64.ts
@@ -1,4 +1,4 @@
-import { Point64 } from "./Point64";
+import { Point64, isPoint64 } from "./Point64";
 
 export const isPath64 = (obj: unknown): obj is Path64 => {
   return obj instanceof Path64 && obj.type === Path64TypeName;
@@ -8,22 +8,49 @@ export const Path64TypeName = "Path64";
 
 export class Path64 extends Array<Point64> {
   readonly type: typeof Path64TypeName;
-  
+
   constructor();
-  constructor(...paths: Point64[]);
   constructor(arrayLength: number);
-  constructor(...args:Point64[] | [number]) {
-    if (args.length === 0) {
+  constructor(...paths: Point64[]);
+  constructor(...args: [] | [number] | Point64[]);
+  constructor(...args: [] | [number] | Point64[]) {
+    const len = args.length;
+    if (len === 0) {
       super();
     } else if (typeof args[0] === "number") {
       super(args[0]);
     } else {
-      super();
-      for (const pt of args as Point64[]) {
-        this.push(Point64.clone(pt));
+      super(len);
+      for (let i = 0; i < len; i++) {
+        const pt = args[i];
+        if (isPoint64(pt)) {
+          this[i] = Point64.clone(pt);
+        } else {
+          throw Error("todo: change message");
+        }
       }
     }
     this.type = Path64TypeName;
+  }
+
+  static clone(path: Iterable<Point64>): Path64 {
+    const result = new Path64();
+    result.pushRange(path);
+    return result;
+  }
+
+  override push(...path: Point64[]) {
+    for (const pt of path) {
+      super.push(Point64.clone(pt));
+    }
+    return this.length;
+  }
+
+  pushRange(path: Iterable<Point64>) {
+    for (const pt of path) {
+      super.push(Point64.clone(pt));
+    }
+    return this.length;
   }
 
   clear() {

--- a/src/Core/PathD.ts
+++ b/src/Core/PathD.ts
@@ -1,4 +1,4 @@
-import { PointD } from "./PointD";
+import { PointD, isPointD } from "./PointD";
 
 export const isPathD = (obj: unknown): obj is PathD => {
   return obj instanceof PathD && obj.type === PathDTypeName;
@@ -10,20 +10,47 @@ export class PathD extends Array<PointD> {
   readonly type: typeof PathDTypeName;
 
   constructor();
-  constructor(...paths: PointD[]);
   constructor(arrayLength: number);
-  constructor(...args: PointD[]|[number]) {
-    if (args.length === 0) {
+  constructor(...paths: PointD[]);
+  constructor(...args: [] | [number] | PointD[]);
+  constructor(...args: [] | [number] | PointD[]) {
+    const len = args.length;
+    if (len === 0) {
       super();
     } else if (typeof args[0] === "number") {
       super(args[0]);
     } else {
-      super();
-      for (const pt of args as PointD[]) {
-        this.push(PointD.clone(pt));
+      super(len);
+      for (let i = 0; i < len; i++) {
+        const pt = args[i];
+        if (isPointD(pt)) {
+          this[i] = PointD.clone(pt);
+        } else {
+          throw Error("todo: change message");
+        }
       }
     }
     this.type = PathDTypeName;
+  }
+
+  static clone(path: Iterable<PointD>): PathD {
+    const result = new PathD();
+    result.pushRange(path);
+    return result;
+  }
+
+  override push(...path: PointD[]) {
+    for (const pt of path) {
+      super.push(PointD.clone(pt));
+    }
+    return this.length;
+  }
+
+  pushRange(path: Iterable<PointD>) {
+    for (const pt of path) {
+      super.push(PointD.clone(pt));
+    }
+    return this.length;
   }
 
   clear() {

--- a/src/Core/Paths64.ts
+++ b/src/Core/Paths64.ts
@@ -1,4 +1,4 @@
-import { Path64 } from "./Path64";
+import { Path64, isPath64 } from "./Path64";
 import { Point64 } from "./Point64";
 
 export const isPaths64 = (obj: unknown): obj is Paths64 => {
@@ -11,21 +11,33 @@ export class Paths64 extends Array<Path64> {
   readonly type: typeof Paths64TypeName;
 
   constructor();
-  constructor(...paths: Iterable<Point64>[]);
   constructor(arrayLength: number);
-
-  constructor(
-    ...args: Iterable<Point64>[] | [number]
-  ) {
-    if (args.length === 0) {
+  constructor(...paths: Path64[]);
+  constructor(...args: [] | [number] | Path64[]);
+  constructor(...args: [] | [number] | Path64[]) {
+    const len = args.length;
+    if (len === 0) {
       super();
     } else if (typeof args[0] === "number") {
       super(args[0]);
     } else {
-      super();
-      this.push(...args as Iterable<Point64>[]);
+      super(len);
+      for (let i = 0; i < len; i++) {
+        const path = args[i];
+        if (isPath64(path)) {
+          this[i] = Path64.clone(path);
+        } else {
+          throw Error("todo: change message");
+        }
+      }
     }
     this.type = Paths64TypeName;
+  }
+
+  static clone(paths: Iterable<Iterable<Point64>>): Paths64 {
+    const result = new Paths64();
+    result.pushRange(paths);
+    return result;
   }
 
   clear() {
@@ -37,7 +49,14 @@ export class Paths64 extends Array<Path64> {
 
   override push(...paths: Iterable<Point64>[]) {
     for (const path of paths) {
-      super.push(new Path64(...path));
+      super.push(Path64.clone(path));
+    }
+    return this.length;
+  }
+
+  pushRange(paths: Iterable<Iterable<Point64>>) {
+    for (const path of paths) {
+      super.push(Path64.clone(path));
     }
     return this.length;
   }

--- a/src/Core/PathsD.ts
+++ b/src/Core/PathsD.ts
@@ -1,4 +1,4 @@
-import { PathD } from "./PathD";
+import { PathD, isPathD } from "./PathD";
 import { PointD } from "./PointD";
 
 export const isPathsD = (obj: unknown): obj is PathsD => {
@@ -11,19 +11,33 @@ export class PathsD extends Array<PathD> {
   readonly type: typeof PathsDTypeName;
 
   constructor();
-  constructor(...paths: Iterable<PointD>[]);
   constructor(arrayLength: number);
-
-  constructor(...args: Iterable<PointD>[] | [number]) {
-    if (args.length === 0) {
+  constructor(...paths: PathD[]);
+  constructor(...args: [] | [number] | PathD[]);
+  constructor(...args: [] | [number] | PathD[]) {
+    const len = args.length;
+    if (len === 0) {
       super();
     } else if (typeof args[0] === "number") {
       super(args[0]);
     } else {
-      super();
-      this.push(...args as Iterable<PointD>[]);
+      super(len);
+      for (let i = 0; i < len; i++) {
+        const path = args[i];
+        if (isPathD(path)) {
+          this[i] = PathD.clone(path);
+        } else {
+          throw Error("todo: change message");
+        }
+      }
     }
     this.type = PathsDTypeName;
+  }
+
+  static clone(paths: Iterable<Iterable<PointD>>): PathsD {
+    const result = new PathsD();
+    result.pushRange(paths);
+    return result;
   }
 
   clear() {
@@ -35,7 +49,14 @@ export class PathsD extends Array<PathD> {
 
   override push(...paths: Iterable<PointD>[]) {
     for (const path of paths) {
-      super.push(new PathD(...path));
+      super.push(PathD.clone(path));
+    }
+    return this.length;
+  }
+
+  pushRange(paths: Iterable<Iterable<PointD>>) {
+    for (const path of paths) {
+      super.push(PathD.clone(path));
     }
     return this.length;
   }

--- a/src/Engine/ClipperBase.ts
+++ b/src/Engine/ClipperBase.ts
@@ -9,7 +9,7 @@ import { OutPt } from "./OutPt";
 import { OutRec } from "./OutRec";
 import { PolyPathBase } from "./PolyPathBase";
 import { Vertex } from "./Vertex";
-import { roundToEven, perpendicDistFromLineSqrd } from "../Clipper";
+import { perpendicDistFromLineSqrd, numberToBigInt, roundToEven } from "../Clipper";
 import { ClipType, FillRule, PathType } from "../Core/CoreEnums";
 import {
   crossProduct,
@@ -632,7 +632,7 @@ const getCleanPath = (op: OutPt): Path64 => {
     op2 = op2.next!;
   }
 
-  result.push(Point64.clone(op2.pt));
+  result.push(op2.pt);
 
   let prevOp = op2;
   op2 = op2.next!;
@@ -642,7 +642,7 @@ const getCleanPath = (op: OutPt): Path64 => {
       (op2.pt.x !== op2.next!.pt.x || op2.pt.x !== prevOp.pt.x) &&
       (op2.pt.y !== op2.next!.pt.y || op2.pt.y !== prevOp.pt.y)
     ) {
-      result.push(Point64.clone(op2.pt));
+      result.push(op2.pt);
       prevOp = op2;
     }
     op2 = op2.next!;
@@ -803,18 +803,18 @@ const buildPath = (
   let op2: OutPt;
 
   if (reverse) {
-    lastPt = Point64.clone(op.pt);
+    lastPt = op.pt;
     op2 = op.prev;
   } else {
     op = op.next!;
-    lastPt = Point64.clone(op.pt);
+    lastPt = op.pt;
     op2 = op.next!;
   }
   path.push(lastPt);
 
   while (op2 !== op) {
     if (Point64.notEquals(op2.pt, lastPt)) {
-      lastPt = Point64.clone(op2.pt);
+      lastPt = op2.pt;
       path.push(lastPt);
     }
     if (reverse) {

--- a/src/Minkowski/Minkowski.ts
+++ b/src/Minkowski/Minkowski.ts
@@ -43,12 +43,8 @@ const minkowskiInternal = (
   let h = patLen - 1;
   for (let i = delta; i < pathLen; i++) {
     for (let j = 0; j < patLen; j++) {
-      const quad: Path64 = new Path64(
-        tmp[g][h],
-        tmp[i][h],
-        tmp[i][j],
-        tmp[g][j],
-      );
+      const quad: Path64 = new Path64();
+      quad.pushRange([tmp[g][h], tmp[i][h], tmp[i][j], tmp[g][j]]);
       if (!isPositive(quad)) {
         result.push(reversePath(quad));
       } else {

--- a/src/Offset/ClipperGroup.ts
+++ b/src/Offset/ClipperGroup.ts
@@ -15,7 +15,7 @@ export class ClipperGroup {
     joinType: JoinType,
     endType: EndType = EndType.Polygon,
   ) {
-    this.inPaths = new Paths64(...paths);
+    this.inPaths = Paths64.clone(paths);
     this.joinType = joinType;
     this.endType = endType;
     this.outPath = new Path64();

--- a/src/Offset/ClipperOffset.ts
+++ b/src/Offset/ClipperOffset.ts
@@ -109,7 +109,7 @@ export class ClipperOffset {
     if (Math.abs(delta) < 0.5) {
       for (const group of this._groupList) {
         for (const path of group.inPaths) {
-          this._solution.push(path);
+          this._solution.pushRange([path]);
         }
       }
     } else {

--- a/src/RectClip/RectClip64.ts
+++ b/src/RectClip/RectClip64.ts
@@ -707,7 +707,7 @@ export class RectClip64 {
       }
       if (i < 0) {
         for (const pt of path) {
-          this.add(Point64.clone(pt));
+          this.add(pt);
         }
         return;
       }
@@ -814,7 +814,7 @@ export class RectClip64 {
           path1ContainsPath2(path, this._rectPath)
         ) {
           for (let j = 0; j < 4; j++) {
-            this.add(Point64.clone(this._rectPath[j]));
+            this.add(this._rectPath[j]);
             addToEdge(this._edges[j * 2], this._results[0]!);
           }
         }
@@ -855,11 +855,7 @@ export class RectClip64 {
       if (!this._rect.intersects(this._pathBounds)) {
         continue;
       } else if (this._rect.contains(this._pathBounds)) {
-        const clonedPath: Path64 = new Path64();
-        for (const pt of path) {
-          clonedPath.push(Point64.clone(pt));
-        }
-        result.push(clonedPath);
+        result.push(path);
         continue;
       }
 
@@ -1116,11 +1112,11 @@ export class RectClip64 {
     }
 
     const result: Path64 = new Path64();
-    result.push(Point64.clone(op!.pt));
+    result.push(op!.pt);
     op2 = op!.next;
 
     while (op2 !== op) {
-      result.push(Point64.clone(op2!.pt));
+      result.push(op2!.pt);
       op2 = op2!.next;
     }
 


### PR DESCRIPTION
# Renewal Path64, PathD, Paths64, PathsD.
- Obsolutde Paths64 and PathsD constructor methods whose argument is `Iterable<Iterable<Point>>`.
- Added Paths64 and PathsD constructor methods whose argument is `Path[]`.
- Path64 and PathD push methods now always make clone Points.
- Added clone method.
- Added pushRange method. Those arguments are `Iterable<Iterable<Point>>` or `Iterable<Point>`.