### PR TITLE
Bug fix 20230922 1

### DIFF
--- a/src/Clipper.ts
+++ b/src/Clipper.ts
@@ -619,8 +619,7 @@ export function scalePaths<TPaths extends Paths64 | PathsD>(
 ): TPaths {
   if (isPaths64(paths)) {
     if (isAlmostZero(scale - 1)) {
-      const resultPaths = new Paths64();
-      return resultPaths as TPaths;
+      return Paths64.clone(paths) as TPaths;
     }
 
     const result = new Paths64();

--- a/src/Core/Path64Like.ts
+++ b/src/Core/Path64Like.ts
@@ -16,7 +16,7 @@ export class Path64Like implements Iterable<Point64> {
   *[Symbol.iterator]() {
     for (const w1 of this._wrapedObject) {
       if (isPoint64(w1)) {
-        yield w1;
+        yield Point64.clone(w1);
       } else {
         yield Point64.createScaledPoint(w1.x, w1.y, this._scale);
       }


### PR DESCRIPTION
- Fixed a bug that Path64Like was not cloned when using Point64.
- Fixed a bug that Clipper.scalePaths returned an empty array when using Paths64 and small scale.